### PR TITLE
Update serde to 1.0, cookie to 0.5, and others to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 authors = ["patrick.fernie@gmail.com"]
 
 [dependencies]
-cookie = { version = "0.4", features = ["serialize-serde"] }
-env_logger = "0.3"
+cookie = "0.5"
+env_logger = "0.4.2"
 idna = "0.1"
 log = "0.3"
-reqwest = "0.2"
-serde = "0.8"
-serde_json = "0.8"
-serde_derive = "0.8"
+reqwest = "0.5.2"
+serde = "1.0.6"
+serde_json = "1.0.2"
+serde_derive = "1.0.6"
 try_from = "0.2"
 time = "0.1"
 url = "1.2"

--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -275,7 +275,7 @@ impl CookieStore {
 
     /// Load JSON-formatted cookies from `reader`, skipping any __expired__ cookies
     pub fn load_json<R: BufRead>(reader: R) -> StoreResult<CookieStore> {
-        CookieStore::load(reader, ::serde_json::from_str)
+        CookieStore::load(reader, |cookie| ::serde_json::from_str(cookie))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro)]
 extern crate cookie as raw_cookie;
 extern crate env_logger;
 extern crate idna;


### PR DESCRIPTION
This just starts the process to get user_agent running with the latest dependencies. Unfortunately both `reqwests` 0.6+ and `cookie` 0.6+ need a bit more work to get them running, so we'll have to do that later.