### PR TITLE
Make reqwest_session module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use cookie_store::CookieStore;
 #[macro_use]
 mod session;
 pub use session::{Session, WithSession};
-mod reqwest_session;
+pub mod reqwest_session;
 pub use reqwest_session::ReqwestSession;
 mod utils;
 


### PR DESCRIPTION
This allows other crates to implement proper Error conversion. Before
you couldn't reach Error class in a sane manner.